### PR TITLE
feat(SP-2025-375): Allow use $ENV without set the env

### DIFF
--- a/README.md
+++ b/README.md
@@ -422,6 +422,35 @@ postgresql:
   user: custom_user
 ```
 
+### Environment Variable Handling
+
+When using `$ENV:` prefix in your configuration files, the framework will:
+
+1. Look for the environment variable specified after `$ENV:`
+2. If the environment variable exists, use its value
+3. If the environment variable doesn't exist:
+   - Use the default value defined in your configuration class
+   - Issue a warning indicating that the environment variable is missing
+   - Proceed with execution rather than raising an error
+
+This behavior allows applications to run with partial configurations in development environments or when not all environment variables are available, while still logging appropriate warnings.
+
+Example of fallback to default values:
+
+```python
+# Configuration class with default
+class ApiConfig(SincproConfig):
+    api_key: str = "dev_default_key"  # Default value as fallback
+
+# In config.yml
+api_key: "$ENV:API_KEY"  # References environment variable
+
+# If API_KEY environment variable is not set, the framework will:
+# 1. Log a warning: "Environment variable [API_KEY] is not set for field [api_key]. Using default value: dev_default_key"
+# 2. Use the default value "dev_default_key" 
+# 3. Continue execution without error
+```
+
 Then you can use the config object in your code where it will be loaded all the settings from the yaml file
 for that you will require use the following funciton `build_config_obj`
 
@@ -434,9 +463,6 @@ config = build_config_obj(MyConfig, '/path/to/your/config.yml')
 assert isinstance(config.log_level, str)
 assert isinstance(config.postgresql, PostgresConf)
 ```
-
-
-
 
 ## 📦 Variables
 

--- a/nested_warning_example.py
+++ b/nested_warning_example.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python
+"""
+Script de ejemplo para mostrar warnings de variables de entorno en configuraciones anidadas.
+Este script simula un escenario más complejo con múltiples variables de entorno faltantes
+en diferentes niveles de la configuración.
+"""
+
+import os
+import warnings
+from typing import Dict, Optional
+
+from sincpro_framework.sincpro_conf import SincproConfig, build_config_obj
+
+
+# Clases de configuración anidadas
+class DatabaseConfig(SincproConfig):
+    """Configuración de la base de datos."""
+    host: str = "localhost"
+    port: int = 5432
+    username: str = "admin"
+    password: str = "secure_password"  # Solo para desarrollo, en producción usar variable de entorno
+    
+    
+class ApiConfig(SincproConfig):
+    """Configuración de la API."""
+    url: str = "https://api.example.com"
+    timeout: int = 30
+    key: str = "default-api-key-for-dev"
+
+
+class LoggingConfig(SincproConfig):
+    """Configuración del sistema de logging."""
+    level: str = "DEBUG"
+    file_path: str = "/tmp/app.log"
+
+
+class ComplexConfig(SincproConfig):
+    """Configuración completa de la aplicación con componentes anidados."""
+    database: DatabaseConfig = DatabaseConfig()
+    api: ApiConfig = ApiConfig()
+    logging: LoggingConfig = LoggingConfig()
+
+
+def main():
+    """Función principal que carga la configuración compleja y muestra los resultados."""
+    # Configurar para mostrar todos los warnings
+    warnings.filterwarnings('always')
+    
+    print("Cargando configuración compleja con múltiples variables de entorno faltantes...")
+    print("=" * 80)
+    
+    # Establecemos una variable de entorno para demostrar valores mixtos
+    os.environ["DB_HOST"] = "db.production.example.com"
+    
+    # Cargamos la configuración desde el archivo
+    config_path = os.path.join(os.path.dirname(__file__), "nested_warning_example.yml")
+    config = build_config_obj(ComplexConfig, config_path)
+    
+    # Mostramos los resultados
+    print("\nResultados de la configuración:")
+    print("=" * 80)
+    
+    print("\n[Configuración de Base de Datos]")
+    print(f"Host: {config.database.host}")              # Debería usar el valor de la variable de entorno
+    print(f"Port: {config.database.port}")              # Valor del archivo YAML
+    print(f"Username: {config.database.username}")      # Debería usar el valor por defecto
+    print(f"Password: {config.database.password}")      # Debería usar el valor por defecto
+    
+    print("\n[Configuración de API]")
+    print(f"URL: {config.api.url}")                     # Valor del archivo YAML
+    print(f"Timeout: {config.api.timeout}")             # Valor del archivo YAML
+    print(f"API Key: {config.api.key}")                 # Debería usar el valor por defecto
+    
+    print("\n[Configuración de Logging]")
+    print(f"Level: {config.logging.level}")             # Valor del archivo YAML
+    print(f"File Path: {config.logging.file_path}")     # Debería usar el valor por defecto
+    
+    print("\nComo puedes ver, las variables de entorno faltantes han emitido warnings")
+    print("y se han usado los valores por defecto definidos en las clases de configuración.")
+    print("La aplicación puede continuar ejecutándose sin interrupciones.")
+
+
+if __name__ == "__main__":
+    main() 

--- a/nested_warning_example.yml
+++ b/nested_warning_example.yml
@@ -1,0 +1,19 @@
+# Archivo de configuración con estructuras anidadas que usan variables de entorno
+
+# Configuración de base de datos que usa variables de entorno
+database:
+  host: "$ENV:DB_HOST"
+  port: 5432
+  username: "$ENV:DB_USER"
+  password: "$ENV:DB_PASSWORD"
+  
+# Configuración de API
+api:
+  url: "https://api.example.com"
+  timeout: 30
+  key: "$ENV:API_KEY"
+  
+# Configuración de logging
+logging:
+  level: "INFO"
+  file_path: "$ENV:LOG_FILE_PATH" 

--- a/tests/config/resources/env_vars_test.yml
+++ b/tests/config/resources/env_vars_test.yml
@@ -1,0 +1,5 @@
+# Configuration file for testing environment variable replacement
+# This file contains values that reference environment variables
+
+string_value: "$ENV:TEST_STRING"
+int_value: "$ENV:TEST_INT" 

--- a/tests/config/resources/missing_env_vars_test.yml
+++ b/tests/config/resources/missing_env_vars_test.yml
@@ -1,0 +1,4 @@
+# Configuration file for testing missing environment variables
+# This file references an environment variable that doesn't exist
+
+string_value: "$ENV:NON_EXISTENT_VAR" 

--- a/tests/config/resources/required_field_test.yml
+++ b/tests/config/resources/required_field_test.yml
@@ -1,0 +1,4 @@
+# Configuration file for testing required fields with missing environment variables
+# This file sets a required field to a non-existent environment variable
+
+required_value: "$ENV:NON_EXISTENT_VAR" 

--- a/tests/config/test_env_variables.py
+++ b/tests/config/test_env_variables.py
@@ -1,0 +1,96 @@
+"""Tests for environment variable handling in configuration system.
+
+This module verifies the following configuration behaviors:
+1. Environment variables are correctly loaded from config files
+2. Default values are properly used when environment variables are missing
+3. Validation errors are raised for required fields with no default values
+"""
+
+import os
+import warnings
+from typing import Optional
+
+import pytest
+from pydantic import ValidationError
+
+from sincpro_framework.sincpro_conf import SincproConfig, build_config_obj
+
+# Test resource file paths
+TEST_RESOURCES_PATH = os.path.join(os.path.dirname(__file__), "resources")
+CONFIG_WITH_ENV_VARS = os.path.join(TEST_RESOURCES_PATH, "env_vars_test.yml")
+CONFIG_WITH_MISSING_ENV_VARS = os.path.join(TEST_RESOURCES_PATH, "missing_env_vars_test.yml")
+CONFIG_WITH_REQUIRED_FIELD = os.path.join(TEST_RESOURCES_PATH, "required_field_test.yml")
+
+
+# Configuration models for testing - prefixed with _ to prevent pytest collection
+class _ConfigWithDefaults(SincproConfig):
+    """Test configuration model with default values for all fields."""
+
+    string_value: str = "default_string"
+    int_value: int = 42
+    nested_value: Optional[dict] = None
+
+
+class _ConfigWithRequiredField(SincproConfig):
+    """Test configuration model with a required field (no default value)."""
+
+    required_value: str  # No default = required
+
+
+def test_environment_variables_are_replaced(monkeypatch):
+    """Verify that environment variables in config files are replaced with their values.
+
+    This test ensures that when environment variables are defined in the system,
+    the configuration system correctly replaces the $ENV: placeholders with
+    the actual values from those environment variables.
+    """
+    # Arrange: Set environment variables for testing
+    monkeypatch.setenv("TEST_STRING", "value_from_environment")
+    monkeypatch.setenv("TEST_INT", "100")
+
+    # Act: Build configuration object from file with environment variable references
+    config = build_config_obj(_ConfigWithDefaults, CONFIG_WITH_ENV_VARS)
+
+    # Assert: Environment variable values are correctly injected
+    assert config.string_value == "value_from_environment"
+    assert config.int_value == 100
+
+
+def test_default_values_used_when_environment_variables_missing():
+    """Verify that default values are used when referenced environment variables don't exist.
+
+    This test ensures that when a configuration references a non-existent environment
+    variable, the system falls back to the default value defined in the model
+    and issues an appropriate warning.
+    """
+    # Arrange & Act: Capture warnings while loading config with missing env var
+    with warnings.catch_warnings(record=True) as captured_warnings:
+        config = build_config_obj(_ConfigWithDefaults, CONFIG_WITH_MISSING_ENV_VARS)
+
+        # Assert: Warning was issued about the missing environment variable
+        assert len(captured_warnings) == 1
+        warning_message = str(captured_warnings[0].message)
+        assert "NON_EXISTENT_VAR" in warning_message
+        assert "default value" in warning_message
+
+    # Assert: Default values were used instead
+    assert config.string_value == "default_string"
+    assert config.int_value == 42  # Unchanged from default
+
+
+def test_validation_error_for_required_fields_with_missing_env_vars():
+    """Verify that validation errors occur for required fields with missing env vars.
+
+    This test ensures that when a required field (one without a default value)
+    references a non-existent environment variable, the system issues a warning
+    and then Pydantic raises a validation error as expected.
+    """
+    # Arrange & Act: Attempt to load config with required field but missing env var
+    with warnings.catch_warnings(record=True) as captured_warnings:
+        # Assert: ValidationError is raised
+        with pytest.raises(ValidationError):
+            build_config_obj(_ConfigWithRequiredField, CONFIG_WITH_REQUIRED_FIELD)
+
+        # Assert: Warning was issued before the error
+        assert len(captured_warnings) == 1
+        assert "NON_EXISTENT_VAR" in str(captured_warnings[0].message)


### PR DESCRIPTION
This pull request introduces significant improvements to the handling of environment variables in configuration files, including the addition of fallback mechanisms and comprehensive warnings for missing variables. The changes also include new examples and tests to ensure the robustness of these improvements.

Enhancements to environment variable handling:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R425-R453): Added a new section detailing the behavior when using the `$ENV:` prefix in configuration files. This includes steps for handling missing environment variables and using default values with appropriate warnings.
* [`sincpro_framework/sincpro_conf.py`](diffhunk://#diff-4e304feb06974de856dfd82ebf543f860d07ae27972f0173f7c9056d895571efL28-R52): Modified the `resolve_env_variables` method to issue warnings and use default values when environment variables are missing, instead of raising errors.

New examples and tests:

* [`nested_warning_example.py`](diffhunk://#diff-37e7539b90867ddede8594ff627ca2667d7139a8b481892d3cdf66db47b4f7e2R1-R84): Added a new script to demonstrate the handling of nested configuration structures with missing environment variables, including the use of default values and warnings.
* [`tests/config/test_env_variables.py`](diffhunk://#diff-8471551e9f10264bae4a4e20dbb97c841448ceb260c33f49d05b26f148ca23c8R1-R96): Introduced new tests to verify the correct loading of environment variables, the use of default values when variables are missing, and the validation errors for required fields without default values.

Configuration files for testing:

* [`tests/config/resources/env_vars_test.yml`](diffhunk://#diff-710383210d260b6d3e7611247a5a58dee26e5635dc02ac6a19268254a13db94cR1-R5): Added a configuration file to test environment variable replacement.
* [`tests/config/resources/missing_env_vars_test.yml`](diffhunk://#diff-d6554d66850ae8fb4ee8bc63e836846f6c544a0bdaa56b7f8ab6ddd5b98c8f43R1-R4): Added a configuration file to test the handling of missing environment variables.
* [`tests/config/resources/required_field_test.yml`](diffhunk://#diff-edb363cd4c4b88e9ab9865432802e3c5f3ceaa05f32831259611a5839983399aR1-R4): Added a configuration file to test required fields with missing environment variables.# Pull Request Checklist
- [ ] Did you test manually the changes



