### PR TITLE
chore(SP-2025-1705): Improve typing for context

### DIFF
--- a/sincpro_framework/context/framework_context.pyi
+++ b/sincpro_framework/context/framework_context.pyi
@@ -1,0 +1,45 @@
+from typing import TYPE_CHECKING, Any, Dict
+
+if TYPE_CHECKING:
+    from ..use_bus import UseFramework
+
+class FrameworkContext:
+    """
+    Framework context manager that provides automatic metadata propagation
+    and scope management with instance-based storage.
+
+    When used with 'with' statement, returns the UseFramework instance
+    with the context applied.
+    """
+
+    framework: "UseFramework"
+    context: Dict[str, Any]
+    parent_context: Dict[str, Any]
+
+    def __init__(self, framework_instance: "UseFramework", context: Dict[str, Any]) -> None:
+        """
+        Initialize the context manager.
+
+        Args:
+            framework_instance: The UseFramework instance to manage context for
+            context: The context dictionary to apply
+        """
+        ...
+
+    def __enter__(self) -> "UseFramework":
+        """
+        Enter the context manager and return framework instance with context applied.
+
+        Returns:
+            The UseFramework instance with the merged context
+        """
+        ...
+
+    def __exit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> bool:
+        """
+        Exit the context manager and restore previous context.
+
+        Returns:
+            False to not suppress exceptions
+        """
+        ...

--- a/tests/test_context_manager.py
+++ b/tests/test_context_manager.py
@@ -381,7 +381,7 @@ class TestUseFrameworkContext:
             {"level": "outer", "correlation_id": "outer-123", "persistent": "value"}
         ) as outer_app:
             # Verify outer context
-            result_outer = outer_app(ContextTestDTO(message="outer"))
+            result_outer = outer_app(ContextTestDTO(message="outer"), ContextTestResponseDTO)
             assert result_outer.context_data["level"] == "outer"
             assert result_outer.context_data["correlation_id"] == "outer-123"
 
@@ -389,7 +389,9 @@ class TestUseFrameworkContext:
                 {"level": "inner", "correlation_id": "inner-456", "temp": "temp_value"}
             ) as inner_app:
                 # Verify inner context (override + inheritance)
-                result_inner = inner_app(ContextTestDTO(message="inner"))
+                result_inner = inner_app(
+                    ContextTestDTO(message="inner"), ContextTestResponseDTO
+                )
                 assert result_inner.context_data["level"] == "inner"  # overridden
                 assert (
                     result_inner.context_data["correlation_id"] == "inner-456"
@@ -398,7 +400,9 @@ class TestUseFrameworkContext:
                 assert result_inner.context_data["temp"] == "temp_value"  # new
 
             # After inner context exits, outer context should be restored
-            result_outer_restored = outer_app(ContextTestDTO(message="outer restored"))
+            result_outer_restored = outer_app(
+                ContextTestDTO(message="outer restored"), ContextTestResponseDTO
+            )
             assert result_outer_restored.context_data["level"] == "outer"
             assert result_outer_restored.context_data["correlation_id"] == "outer-123"
             assert result_outer_restored.context_data["persistent"] == "value"
@@ -428,7 +432,9 @@ class TestUseFrameworkContext:
 
         with framework.context({"a": "outer_a", "b": "outer_b", "c": "outer_c"}) as outer_app:
             with outer_app.context({"a": "inner_a", "d": "inner_d"}) as inner_app:
-                result = inner_app(ContextTestDTO(message="override test"))
+                result = inner_app(
+                    ContextTestDTO(message="override test"), ContextTestResponseDTO
+                )
 
                 # Should have overridden 'a', inherited 'b' and 'c', and added 'd'
                 assert result.context_data["a"] == "inner_a"  # overridden


### PR DESCRIPTION
# Pull Request Checklist

This pull request introduces a new context manager for the framework, improving how context attributes are propagated and managed during execution. It adds type-safe overloads for DTO execution, enhances context scoping, and updates tests to utilize the new context manager and type annotations for better clarity and correctness.

**Framework context management improvements:**

* Added a new `FrameworkContext` class to `context/framework_context.pyi`, which provides automatic metadata propagation and scope management for context attributes. This enables context scoping using the `with` statement and ensures context restoration after exiting the scope.
* Introduced a new `context` method to the `UseFramework` class, returning a `FrameworkContext` manager for scoped context execution. The method is fully typed and documented, allowing context attributes to be set and restored easily.

**Type safety and overload enhancements:**

* Improved type overloads for the `__call__` method in `UseFramework`, replacing generic DTO types with `DataTransferObject` and `TypeDTOResponse` for better IDE support and type checking. [[1]](diffhunk://#diff-7e395029c4d8de19f0946b18419f7334f6238c8ebfcfb63cf3cf4713e07e05daL79-R84) [[2]](diffhunk://#diff-7e395029c4d8de19f0946b18419f7334f6238c8ebfcfb63cf3cf4713e07e05daL93-R98)
* Updated the `bus` attribute in `UseFramework` to allow `None` during initialization, with an explicit type override for clarity.

**Test updates for new context manager:**

* Updated tests in `test_context_manager.py` to call the framework with explicit DTO response types, verifying context propagation, overriding, and restoration with the new context manager. [[1]](diffhunk://#diff-4d6c1dd9bda5d4cb411422e3dce37567607afda43b71f2ba02a91a64fdb82b58L384-R394) [[2]](diffhunk://#diff-4d6c1dd9bda5d4cb411422e3dce37567607afda43b71f2ba02a91a64fdb82b58L401-R405) [[3]](diffhunk://#diff-4d6c1dd9bda5d4cb411422e3dce37567607afda43b71f2ba02a91a64fdb82b58L431-R437)

- [ ] Did you test manually the changes



