### PR TITLE
fix(SP-2025-1773): Fix bad create app services with all features instances

### DIFF
--- a/sincpro_framework/bus.py
+++ b/sincpro_framework/bus.py
@@ -135,12 +135,6 @@ class FrameworkBus(Bus):
         registered_features = set(self.feature_bus.feature_registry.keys())
         registered_app_services = set(self.app_service_bus.app_service_registry.keys())
         self.logger.debug("Framework bus created")
-        self.logger.debug(
-            f"Registered features: {registered_features}",
-        )
-        self.logger.debug(
-            f"Registered app services: {registered_app_services}",
-        )
 
         intersection_dtos = registered_features.intersection(registered_app_services)
         if intersection_dtos:


### PR DESCRIPTION
# Pull Request Checklist

This pull request refactors how DTO registration and logging are handled in the framework's IoC container and bus initialization. The changes improve error handling for duplicate DTO registrations, streamline logging, and clarify registry updates for features and application services.

### Registration logic and error handling improvements

* Refactored `_register_service` in `sincpro_framework/ioc.py` to provide explicit error messages when attempting to register a DTO that is already present as either a feature or an application service, improving clarity and robustness in registration error handling.
* Updated registry assignment to directly modify `feature_registry` and `app_service_registry` with new DTOs, and ensured the corresponding bus attributes are updated immediately after registration.

### Logging improvements

* Simplified logging in `sincpro_framework/bus.py` by removing redundant debug statements about registered features and app services during bus initialization.
* Changed log messages in `_register_service` to use the `service_type` value for registration events, providing more consistent and informative logs.

### Code simplification

* Removed the previous use of `match` statements for registry selection and consolidated registry updates for better code readability and maintainability.
- [ ] Did you test manually the changes



