### PR TITLE
fix: warnings CI/CD

### DIFF
--- a/.github/actions/prepare-env/action.yml
+++ b/.github/actions/prepare-env/action.yml
@@ -2,7 +2,7 @@ name: "Prepare envinronment"
 description: "Install OS packages and dependencies"
 
 inputs:
-  enviroment:
+  environment:
     description: "Python versions to setup"
     required: true
 
@@ -12,4 +12,4 @@ runs:
     - name: Setup Python
       uses: actions/setup-python@v4
       with:
-        python-version: ${{ inputs.enviroment }}
+        python-version: ${{ inputs.environment }}


### PR DESCRIPTION
# Pull Request Checklist

## Description Dev notes

This pull request corrects a spelling error in the custom GitHub Action configuration file `.github/actions/prepare-env/action.yml`, ensuring consistent and correct usage of the input variable for specifying the Python version.

Key fix:

* Renamed the input variable from `enviroment` to `environment` and updated all references to match the correct spelling. [[1]](diffhunk://#diff-0f5efa855431a20f99faa86bd081b483cd649e063f775c7cf6d9d1f1112ec7e0L5-R5) [[2]](diffhunk://#diff-0f5efa855431a20f99faa86bd081b483cd649e063f775c7cf6d9d1f1112ec7e0L15-R15)

## Checklist

- [ ] Did you test manually the changes
