### PR TITLE
fix: CI/CD provide enviroments to jobs

### DIFF
--- a/.github/workflows/03-release_draft.yaml
+++ b/.github/workflows/03-release_draft.yaml
@@ -9,3 +9,5 @@ jobs:
   validate:
     uses: Sincpro-SRL/.github/.github/workflows/03-release_draft.yaml@main
     secrets: inherit
+    with:
+      environments: '["3.12"]'


### PR DESCRIPTION
# Pull Request Checklist

## Description Dev notes

This pull request makes a minor update to the GitHub Actions workflow configuration. The change adds an `environments` input to the `validate` job in the `.github/workflows/03-release_draft.yaml` file, specifying that the workflow should use environment `3.12`.

## Checklist

- [ ] Did you test manually the changes
