### PR TITLE
chore(SP-2026-91): CI/CD Notificacion por discord

### DIFF
--- a/.github/workflows/05-discord_notify.yaml
+++ b/.github/workflows/05-discord_notify.yaml
@@ -1,0 +1,21 @@
+name: Discord Notification
+
+on:
+  pull_request:
+    types: [closed]
+    branches:
+      - main
+      - release/**
+
+  release:
+    types: [published]
+
+  push:
+    branches:
+      - main
+      - release/**
+
+jobs:
+  discord:
+    uses: Sincpro-SRL/.github/.github/workflows/05-discord_notify.yaml@main
+    secrets: inherit


### PR DESCRIPTION
# Pull Request Checklist

## Description Dev notes

This pull request introduces a new GitHub Actions workflow for Discord notifications. The workflow is designed to send notifications on pull request closures, release publications, and pushes to the `main` and `release/**` branches.

Notification workflow integration:

* Added `.github/workflows/05-discord_notify.yaml` to trigger Discord notifications for pull request closures, release publications, and pushes to important branches.
* Configured the workflow to use a reusable workflow from `Sincpro-SRL/.github/.github/workflows/05-discord_notify.yaml@main` and inherit secrets for secure operation.

## Checklist

- [ ] Did you test manually the changes
