### PR TITLE
chore(SP-2026-944): Opentelemetry embebbed in the logger by default

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -801,70 +801,70 @@ pypi = ["pip (>=24.0)", "platformdirs (>=4.2)", "wheel (>=0.42)"]
 
 [[package]]
 name = "grpcio"
-version = "1.81.0"
+version = "1.81.1"
 description = "HTTP/2-based RPC framework"
 optional = false
 python-versions = ">=3.10"
 groups = ["main", "dev"]
 files = [
-    {file = "grpcio-1.81.0-cp310-cp310-linux_armv7l.whl", hash = "sha256:b4108e5d9d0f651b7eea749116181fe6c315b145661a80ec31f05ec2dbe21af7"},
-    {file = "grpcio-1.81.0-cp310-cp310-macosx_11_0_universal2.whl", hash = "sha256:b76ea9d55cd08fcdbda25d28e0f76679536710acb7fbd5b1f70cb4ac49317265"},
-    {file = "grpcio-1.81.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:4e032feb3bfb4e2749b140a2302a6baa8ead1b9781ff5cf7094e4402b5e9372e"},
-    {file = "grpcio-1.81.0-cp310-cp310-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:725801c7086d7e4cd160e42bb2f54e0aeb976b9568df3cc6f843b15d29b79fb1"},
-    {file = "grpcio-1.81.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:f750a091fff3a3991731abc1f818bdc64874bb3528162732cb4d45f2e07821a6"},
-    {file = "grpcio-1.81.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:8226ba097eed660ef14d36c6a69b85038552bb8b6d17b44a5aa6f9abf48b8e08"},
-    {file = "grpcio-1.81.0-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:40edffb4ec3689373825d367c4457727047a6e554f03245265ecc8cc03215f22"},
-    {file = "grpcio-1.81.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:f85570a016d794c29b1e76cf22f67af4486ddbe779e0f30674f138fa4e1769ec"},
-    {file = "grpcio-1.81.0-cp310-cp310-win32.whl", hash = "sha256:3755c9669307cad18e7e009860fdea98118978d2300451bd8530a53048e741e7"},
-    {file = "grpcio-1.81.0-cp310-cp310-win_amd64.whl", hash = "sha256:909bb3222b53235498d2c5817a0596d82b0aaea490ba93fdf1b060e2938a543c"},
-    {file = "grpcio-1.81.0-cp311-cp311-linux_armv7l.whl", hash = "sha256:794e6aa648e8df47d8f908dc8c3b42347d04ec58438f1dcd4e445f09b4f6b0ce"},
-    {file = "grpcio-1.81.0-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:cd78145b7f7784661c524624f3526c9c6f891b30a4b54cb93a40806d0d0d61e9"},
-    {file = "grpcio-1.81.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:638ccc1b86f7540170a169cb900799b9296a1381e47879ce60b0de9d3db73d33"},
-    {file = "grpcio-1.81.0-cp311-cp311-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:21ec30b9ea320c8207ea7cd05873ad64aa69fdd0e81b6758b3347983ba20b50a"},
-    {file = "grpcio-1.81.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:dbdb99986548a7e87f8343805ef315fd4eb50ffaabf4fb1206e42f2542bb805d"},
-    {file = "grpcio-1.81.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:c36f5d5e97944cbda2d4096b4ae262e6e68506246b61582acf1b8591607f3ccc"},
-    {file = "grpcio-1.81.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:9f355384e5543ab77a755a7085225ecc19f32b76032e851cbd8145715d79dec8"},
-    {file = "grpcio-1.81.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:77eb4e9fe61486bd1198cc7236ebb0f70e66234e63c0348f40bc2553ed16a88b"},
-    {file = "grpcio-1.81.0-cp311-cp311-win32.whl", hash = "sha256:7915a2e63acdc05264a206e1bddfd8e1fb8a29e406c18d72d30f8c124e021374"},
-    {file = "grpcio-1.81.0-cp311-cp311-win_amd64.whl", hash = "sha256:5e925a70fe99fe5794f7beca0ea034c75f068afcc356d79047e73f99cdcca34c"},
-    {file = "grpcio-1.81.0-cp312-cp312-linux_armv7l.whl", hash = "sha256:57b3b0e73a518fa286959b40c3eddd02703504ca186e8b7b2945954519bd8b2c"},
-    {file = "grpcio-1.81.0-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:8bb1789c94322a13336a2b6c58d9c14d68f8628b6e24205a799c69f5bf8516ce"},
-    {file = "grpcio-1.81.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:e4d053900a0d24b75d7521139a3872150301b3d6bde3bed5e12318fb25791e4d"},
-    {file = "grpcio-1.81.0-cp312-cp312-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:db217c2e52931719f9937bd12082cd4d7b495b35803d5760686975c285924bf8"},
-    {file = "grpcio-1.81.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:19f201da7b4e5c0559198abe5a97157e726f3abe6e8f5e832d4a50740f6dcc22"},
-    {file = "grpcio-1.81.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:275144b0115353339dbb8a6f28a9cf8997b5bf40e37f8f66ac0b0ea57e95b43f"},
-    {file = "grpcio-1.81.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:5192857589f223e5a98ff0e31f6e551b19040e647d17bfe10116c8a2ce3b8696"},
-    {file = "grpcio-1.81.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:c6ff087cb1f563f47b504b4e29e684129fc5ae4863faf3ebca08a327764ee6cb"},
-    {file = "grpcio-1.81.0-cp312-cp312-win32.whl", hash = "sha256:98c6240f563178fc5877bd50e6ff274463e53e1472128f4110742450739659fa"},
-    {file = "grpcio-1.81.0-cp312-cp312-win_amd64.whl", hash = "sha256:87e33b7afcfb3585121b5f007d2c52b8c534104d18f556e840d35193ca2a9141"},
-    {file = "grpcio-1.81.0-cp313-cp313-linux_armv7l.whl", hash = "sha256:62bbe463c9f0f2ff24e31bd25f8dd8b4bae78900e315915a3195a0ef1471a855"},
-    {file = "grpcio-1.81.0-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:43c121e135ae44d1559b430db2b2dfad7421cbbe40e1deba506c7dc62b439719"},
-    {file = "grpcio-1.81.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f345de40ef2e65f63645d53d251824e6070e07804827c5b00ec2e44555f9f901"},
-    {file = "grpcio-1.81.0-cp313-cp313-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:8c0855a350886f713b9e458e2a10d208009dcaa849f574e39cd6067db1fe1279"},
-    {file = "grpcio-1.81.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:a524cd530900bd24511fcb7f2ed144da4ea37711c4b094475d0bceca7a93a170"},
-    {file = "grpcio-1.81.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:e7746ba3e6efc9e2b748eff59470a2b8684d5a9ec607c6580bcaa5be175820bc"},
-    {file = "grpcio-1.81.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:aaaa4f7f2057d795952e4eacf3f342be8b5b156992f6ac85023c8b98794ebd47"},
-    {file = "grpcio-1.81.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:0fba53cb96004b2b7fb758b46b2288cb49d0b658316a4e73f3ef67230616ee65"},
-    {file = "grpcio-1.81.0-cp313-cp313-win32.whl", hash = "sha256:c197e2ef75a442528072b29e9755da299110e8610e8bcbb59a6b4cf55384f005"},
-    {file = "grpcio-1.81.0-cp313-cp313-win_amd64.whl", hash = "sha256:194eddfacc84d80f50512e9fd4ee851d5f2499f18f299c95aa8fb4748f0537e0"},
-    {file = "grpcio-1.81.0-cp314-cp314-linux_armv7l.whl", hash = "sha256:a9351055f52660b58f3d4890ea66188b5134399f82b11aa0c55bd4b99eff5390"},
-    {file = "grpcio-1.81.0-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:300f3337b6425fd16ead9a4f9b2ac25801acb64aa5bc0b99eb69901645b2b1d2"},
-    {file = "grpcio-1.81.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:97bbd623f7ded558fd4f7cb5a4f600c4d4de65c5dd364c83a5b14b2a10a2d3b5"},
-    {file = "grpcio-1.81.0-cp314-cp314-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:ff83d889e3ebf6341c8c7864ad8031591ad5ca61599072fc511644d1eb962d2b"},
-    {file = "grpcio-1.81.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c4fe218c5a35e1d87a5a26544237f1fa41dfd9cbd3c856b0810a30061f8b0aaf"},
-    {file = "grpcio-1.81.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:b8b025b6af43ee0ad4a70307025d77bcab5adde7c4597786010d802c203e9fc5"},
-    {file = "grpcio-1.81.0-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:3d4e0ce5a40a998cf608c8ba60ecfe18fdf364a9aa193ae4ac3faeecd0e86757"},
-    {file = "grpcio-1.81.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:aa948712c8e5fa40ec250870bda14bc7578e1bb832a8912d9d2a0f720518edbe"},
-    {file = "grpcio-1.81.0-cp314-cp314-win32.whl", hash = "sha256:fbbe81314a9d92156abce8b62c09364eb8bafc0ca2a19919a45ec64b5c6cb664"},
-    {file = "grpcio-1.81.0-cp314-cp314-win_amd64.whl", hash = "sha256:b93cee313cae4e113fbb3a0ce1ea5633db6f63cfde2b2dc1d817429026b2a50b"},
-    {file = "grpcio-1.81.0.tar.gz", hash = "sha256:a5acd7efd3b1fe9b4eb0bcaaa1507eed68a0ad0678b654c3f7b464df9ba9dca5"},
+    {file = "grpcio-1.81.1-cp310-cp310-linux_armv7l.whl", hash = "sha256:6f9a0c9c1cc15c112d1c053064fd032b64917062292c3d70aea280e02ae10b77"},
+    {file = "grpcio-1.81.1-cp310-cp310-macosx_11_0_universal2.whl", hash = "sha256:69ef28e54fc85397f91b8c19592b8ef3d81952080366914823bd8572a2958120"},
+    {file = "grpcio-1.81.1-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:15641444eca4a29358107b3dceb74c1c6305c55c822fd199b458aaea4068a7fb"},
+    {file = "grpcio-1.81.1-cp310-cp310-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:d4b2dddfc219f54f956ccd53cf76a1d338ffe68fc7f2849ec9c7feb9927ff692"},
+    {file = "grpcio-1.81.1-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ca1cc11d82677b9662082e5478b7528e2b7db7beaa6bdff42bd62789d81be399"},
+    {file = "grpcio-1.81.1-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:aa2ba7d2ad6df4d80127cea65e5b8d5e2c3adbf153ff4804452836328aca7c54"},
+    {file = "grpcio-1.81.1-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:592b5fee597faa91cce2dd294dd7d9a1c83d76c4dbf877e33ec1adb866b2fbed"},
+    {file = "grpcio-1.81.1-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:62481553b1793a27e9b9c3cf9e5bd483ef045ca72462592074b46d42b0c4d9b9"},
+    {file = "grpcio-1.81.1-cp310-cp310-win32.whl", hash = "sha256:bb693b1e3d9a2f3fd228e2110daf4b5aeedb36761ca1e4282f74725f6d89f611"},
+    {file = "grpcio-1.81.1-cp310-cp310-win_amd64.whl", hash = "sha256:88268ca418cacea64cecb0d1d600d3c6b3a8038fcba02e1e205178c5b1f47661"},
+    {file = "grpcio-1.81.1-cp311-cp311-linux_armv7l.whl", hash = "sha256:d71d30f2d92f67d944631c523713934fee37292469e182ebcd2c1dd8a64ce53f"},
+    {file = "grpcio-1.81.1-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:b137f4bf3ada9dc44d411478decc6ff09a79ed30b306cd2abaa98408c3588137"},
+    {file = "grpcio-1.81.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:a3acb384427816dd5d470f47e62137b87f74da694faa8a50147012cf40df276a"},
+    {file = "grpcio-1.81.1-cp311-cp311-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:f9a0ebbe45c29b5e5866593c12b78bd9035f0f0f0d4bc8361680cd580d99db49"},
+    {file = "grpcio-1.81.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0a37165cc80b1a368384b383e63a4c38116a10467ae44c904d2d7468c4470ec2"},
+    {file = "grpcio-1.81.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:6282caffb41ec326d4cb67ca9cf53b739d1b2f975a2acb498c7418e9f7d9a416"},
+    {file = "grpcio-1.81.1-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:a35009284d0d3d5c2c9601c164a911b8b4331608d98a9a66d47d97bb2f522b70"},
+    {file = "grpcio-1.81.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:1b22c80559854b789a01fd89e8929b3798a156c0829b5282a8939f33ad4115ad"},
+    {file = "grpcio-1.81.1-cp311-cp311-win32.whl", hash = "sha256:428bec0161b48d8cf583c068591bc0016d0d9cfff52462b72b3884861ea768c5"},
+    {file = "grpcio-1.81.1-cp311-cp311-win_amd64.whl", hash = "sha256:30e825f6848d9f18bba350ed6c75c1b02a0b5184474a31db9a32b1fa66fd8c79"},
+    {file = "grpcio-1.81.1-cp312-cp312-linux_armv7l.whl", hash = "sha256:8b39472beafc0bdcafc4c8c73ad082ebfdb449d566897a61e7acb4fa88089115"},
+    {file = "grpcio-1.81.1-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:12b7524c88d4026d3dcb7b0ebe16b6714f3b4af402ddd0f0639ab064a00c87c3"},
+    {file = "grpcio-1.81.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:1e123f9b37edb8375fd74130d1f69c944bbf0a7b06761ae7211154b8759e94d2"},
+    {file = "grpcio-1.81.1-cp312-cp312-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:2c2e2ae6867c2966b8daccc836d54a13218e0007e9a490aeb81dd05be64d22d7"},
+    {file = "grpcio-1.81.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:766bc7c9a9c340342f4c864ccbda8e78111e4751f13b895812b9c148fb79e9d0"},
+    {file = "grpcio-1.81.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:b259a04a737cb3496be0901328eb8b7552ed8df4865d8c8f1cf1bffcfc0776a3"},
+    {file = "grpcio-1.81.1-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:85b10a45b8993d195c4f3ff57025b8d1e11834909ee475c403bfa60cb4caefaf"},
+    {file = "grpcio-1.81.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:8ea1936c26b99999b27479853039a7f34713f56c49375ad52b38535ec93a796c"},
+    {file = "grpcio-1.81.1-cp312-cp312-win32.whl", hash = "sha256:a185a04039df6cae8648bc8ab6d6fde7bf94f7188ecf7828e76ac52eef1e41d6"},
+    {file = "grpcio-1.81.1-cp312-cp312-win_amd64.whl", hash = "sha256:3ad74f8bb1a18963914c5452d289422830b39459e8776ebbcd207be1fbfb1d94"},
+    {file = "grpcio-1.81.1-cp313-cp313-linux_armv7l.whl", hash = "sha256:b10e1ff4756ed27d5a29d7fc79cfce7ef1ff56ad20025b89bac7cf79e09abbbe"},
+    {file = "grpcio-1.81.1-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:819edbdcb42ab8598b494bcf0222684bbb7a3c772bd1b1f0be7e029a6063c28e"},
+    {file = "grpcio-1.81.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:c5bf2dc311127d91230cc79b92188c082634a06cf66c5234db49a43b910183b0"},
+    {file = "grpcio-1.81.1-cp313-cp313-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:e8ca6a1fcdb2943c9cbc1804a1baf3acb6071d72a471591678ded84218006e14"},
+    {file = "grpcio-1.81.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:e64dd101d380a115cc5a0c7856788adb535f1a4e21fc543775602f8be95180ae"},
+    {file = "grpcio-1.81.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:98a07f9bf591e3a8919797bee1c53f026ba4acd587e5a4404c8e57c9ec36b2a5"},
+    {file = "grpcio-1.81.1-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:c261d74b1a945cf895a9d6eccd1685a8e837531beaab782da4d630a8d12deffb"},
+    {file = "grpcio-1.81.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:58ad1131c300d3c9b933802b3cc4dc69d380822935ba50b28703156ea826fbf7"},
+    {file = "grpcio-1.81.1-cp313-cp313-win32.whl", hash = "sha256:78e29211f26da2fdd0e9c6d2b79f489476140cf7029b6a64808ade7ca4156a42"},
+    {file = "grpcio-1.81.1-cp313-cp313-win_amd64.whl", hash = "sha256:edb59506291b647a30884b1d51a599d605f40b20af4a7dc3d33786a47a31de60"},
+    {file = "grpcio-1.81.1-cp314-cp314-linux_armv7l.whl", hash = "sha256:506f48f2f9c29b143fca3dad7b0d518c188b6c9648c75a2ae6e2d9f2c13a060b"},
+    {file = "grpcio-1.81.1-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:d865db4a6318e1c1bea83292e0ed231090538fc4ca45425b0f0480eb338bbc6e"},
+    {file = "grpcio-1.81.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:e2aa72e3ce1770317ef534f63d397b55e130725f5149bd36077c3b539019db27"},
+    {file = "grpcio-1.81.1-cp314-cp314-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:0490c30c261eded63f3f354979f9dc4502a9fb944cccb60cd9dc85f5a7349854"},
+    {file = "grpcio-1.81.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:410482da976329fe5f4067270401b12cf2bd552ff8020f054ecfaddb5475f9d6"},
+    {file = "grpcio-1.81.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:e3657301562ac3cb8018d30d0d3ebfa39932239f7b5703422057ef14b69949f5"},
+    {file = "grpcio-1.81.1-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:24c8e57504c8f45b237e40b99262d181071e5099a07053695b75d97bb53053a0"},
+    {file = "grpcio-1.81.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:b427c19380991a4eaab2f6144b64b99b412043314c6bf4ab544f97bb31ee4190"},
+    {file = "grpcio-1.81.1-cp314-cp314-win32.whl", hash = "sha256:61233fe8951e5c85dff81c2458b6528624760166946b5b47ea150a589168411f"},
+    {file = "grpcio-1.81.1-cp314-cp314-win_amd64.whl", hash = "sha256:3768a5ff1b2125e6f552e561b6b2dca0e64982d8949689b4df145cf8b98d7821"},
+    {file = "grpcio-1.81.1.tar.gz", hash = "sha256:6fa10a767143a5e82e8eaab53918af0cd8909a57a27f8cb2288b80a613ac671b"},
 ]
 
 [package.dependencies]
 typing-extensions = ">=4.12,<5.0"
 
 [package.extras]
-protobuf = ["grpcio-tools (>=1.81.0)"]
+protobuf = ["grpcio-tools (>=1.81.1)"]
 
 [[package]]
 name = "h11"
@@ -3218,14 +3218,14 @@ type = ["importlib_metadata (>=7.0.2) ; python_version < \"3.10\"", "jaraco.deve
 
 [[package]]
 name = "sincpro-log"
-version = "1.0.1"
+version = "1.1.1"
 description = "A logging module for sincpro applications"
 optional = false
 python-versions = "<4.0,>=3.12"
 groups = ["main"]
 files = [
-    {file = "sincpro_log-1.0.1-py3-none-any.whl", hash = "sha256:a85e7c9d2af26a1e8a6f5414fbd19cc4de0f52f2a0ff84625cd29a187eb5ddca"},
-    {file = "sincpro_log-1.0.1.tar.gz", hash = "sha256:c43ff76cfa75188670cddd2febafade866d38c0ea0b7bba0782d66f661079f5c"},
+    {file = "sincpro_log-1.1.1-py3-none-any.whl", hash = "sha256:f7ba186be720e1786689a21d796120511ca97a241bb86edd9ab635f35adf826b"},
+    {file = "sincpro_log-1.1.1.tar.gz", hash = "sha256:0a452f8306ed00729a70927e00053965f1065c3d7424f6f75a05fb0860e20956"},
 ]
 
 [package.dependencies]
@@ -3538,4 +3538,4 @@ opentelemetry = ["opentelemetry-api", "opentelemetry-exporter-otlp-proto-grpc", 
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.12"
-content-hash = "b83f8679bd4174bc6c622e3cab6a1e99c2f018039f7fad69eb567a71768d87c6"
+content-hash = "e47007b6d993bc2e31e64d5c9f5df4a9acf0c7d5c7ba74a880773567a832ecf8"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ python = "^3.12"
 dependency-injector = "^4.48.3"
 pydantic = "^2.12.5"
 pyyaml = ">=6.0.1"
-sincpro-log = "^1.0.1"
+sincpro-log = "^1.1.1"
 opentelemetry-api = {version = ">=1.20", optional = true}
 opentelemetry-sdk = {version = ">=1.20", optional = true}
 opentelemetry-exporter-otlp-proto-grpc = {version = ">=1.20", optional = true}
@@ -62,5 +62,7 @@ build-backend = "poetry.core.masonry.api"
 line-length = 94
 
 [tool.pyright]
+venvPath = "."
+venv = ".venv"
 reportInvalidTypeVarUse = "none"
 reportInvalidTypeForm = "none"

--- a/sincpro_framework/tracing/provider.py
+++ b/sincpro_framework/tracing/provider.py
@@ -2,6 +2,8 @@
 
 from typing import Any
 
+from sincpro_log.logger import LoggerProxy
+
 from ..sincpro_conf import settings
 
 # Private provider owned by sincpro. Kept separate from the global OTel provider
@@ -10,7 +12,23 @@ from ..sincpro_conf import settings
 _sincpro_provider: Any = None
 
 
-def setup_otlp_provider(service_name: str) -> None:
+def _get_current_otel_context() -> dict:
+    """Return trace_id and span_id from the currently active OTel span, or {}."""
+    try:
+        from opentelemetry import trace
+
+        span_ctx = trace.get_current_span().get_span_context()
+        if span_ctx.is_valid:
+            return {
+                "trace_id": format(span_ctx.trace_id, "032x"),
+                "span_id": format(span_ctx.span_id, "016x"),
+            }
+    except Exception:
+        pass
+    return {}
+
+
+def setup_otlp_provider(service_name: str, logger: LoggerProxy | None = None) -> None:
     """Configure a dedicated TracerProvider for this bounded context.
 
     Always creates a private TracerProvider with the given ``service_name`` —
@@ -69,6 +87,11 @@ def setup_otlp_provider(service_name: str) -> None:
     current_type: str = type(trace.get_tracer_provider()).__name__
     if current_type in ("ProxyTracerProvider", "NoOpTracerProvider"):
         trace.set_tracer_provider(provider)
+
+    # Wire OTel span context into the logger so every framework.logger.info(...)
+    # call automatically carries trace_id/span_id from the active span.
+    if logger is not None:
+        logger.set_getter_context(_get_current_otel_context)
 
 
 def get_framework_tracer(instrumentation_name: str) -> Any:

--- a/sincpro_framework/use_bus.py
+++ b/sincpro_framework/use_bus.py
@@ -130,7 +130,9 @@ class UseFramework(ContextMixin):
 
         # Configure OTLP provider if opentelemetry-sdk is installed and
         # OTEL_EXPORTER_OTLP_ENDPOINT is set. No-op otherwise.
-        setup_otlp_provider(self._logger_name)
+        # When OTel is active, also wires the current span context into the logger
+        # so framework.logger.info(...) carries trace_id/span_id automatically.
+        setup_otlp_provider(self._logger_name, self.logger)
 
     def add_dependency(self, name, dep: Any):
         """
@@ -349,7 +351,7 @@ class UseFramework(ContextMixin):
 
     @property
     def logger(self) -> LoggerProxy:
-        """Get bundle context logger"""
+        """Get the bundle context logger."""
         if not self._is_logger_configured:
             self._logger = create_logger(self._logger_name)
             self._is_logger_configured = True

--- a/tests/tracing/test_tracing.py
+++ b/tests/tracing/test_tracing.py
@@ -612,3 +612,94 @@ def test_carrier_without_otel_emits_warning(monkeypatch):
             # trace IDs are still generated (UUIDs), execution completes normally
             assert "trace_id" in traced._get_context()
             traced(WarnDTO())
+
+
+# ---------------------------------------------------------------------------
+# logger getter — framework.logger.info() outside Feature.execute()
+# ---------------------------------------------------------------------------
+
+
+def test_otel_getter_provides_trace_id_outside_execution(otel_setup):
+    """(OTel) framework.logger carries trace_id from the active OTel span even when
+    called outside a Feature.execute() — the getter reads the span directly.
+
+    This is the core use case: framework.logger.info(...) called between requests
+    or between framework() calls automatically includes the host trace_id.
+    """
+    from opentelemetry import trace
+    from sincpro_log.logger import create_logger
+
+    from sincpro_framework.tracing.provider import _get_current_otel_context
+
+    logger = create_logger("test-outside-exec")
+    logger.set_getter_context(_get_current_otel_context)
+
+    tracer = trace.get_tracer("host")
+    with tracer.start_as_current_span("http-handler") as span:
+        expected_trace_id = format(span.get_span_context().trace_id, "032x")
+        expected_span_id = format(span.get_span_context().span_id, "016x")
+
+        fields = logger.logger_fields
+        assert fields["trace_id"] == expected_trace_id
+        assert fields["span_id"] == expected_span_id
+
+    # After span ends, no trace context leaks into the logger
+    assert "trace_id" not in logger.logger_fields
+
+
+def test_otel_getter_empty_when_no_active_span(otel_setup):
+    """(OTel) The getter returns {} when no span is active — logger stays clean."""
+    from sincpro_framework.tracing.provider import _get_current_otel_context
+
+    result = _get_current_otel_context()
+    assert result == {}
+
+
+def test_otel_getter_suppressed_during_execution(otel_setup):
+    """(OTel) Inside Feature.execute(), _bind_span_to_logger sets _temporal_fields,
+    which suppresses the getter — no double-binding or conflict."""
+    from opentelemetry import trace
+
+    from sincpro_framework.tracing.provider import _get_current_otel_context
+
+    fw = UseFramework("getter-suppression-test", log_after_execution=False)
+
+    class GS_DTO(DataTransferObject):
+        pass
+
+    captured: dict = {}
+
+    @fw.feature(GS_DTO)
+    class GS_Feature(Feature):
+        def execute(self, dto: GS_DTO) -> None:
+            # Inside execute, _temporal_fields are set by _bind_span_to_logger.
+            # The getter must NOT be called (logger.is_contextualized would be True).
+            captured["temporal"] = dict(fw.logger._temporal_fields)
+            captured["fields"] = dict(fw.logger.logger_fields)
+            return None
+
+    fw.logger.set_getter_context(_get_current_otel_context)
+
+    tracer = trace.get_tracer("host")
+    with tracer.start_as_current_span("http-handler"):
+        fw(GS_DTO())
+
+    # _temporal_fields were set during execution (by _bind_span_to_logger)
+    assert "trace_id" in captured["temporal"]
+    # logger_fields also had trace_id (from _temporal_fields, not getter)
+    assert "trace_id" in captured["fields"]
+
+
+def test_logger_getter_not_registered_without_otlp_endpoint():
+    """Without OTEL_EXPORTER_OTLP_ENDPOINT, setup_otlp_provider must NOT register
+    the getter — the logger stays unmodified (backwards-compatible behavior)."""
+    from sincpro_log.logger import create_logger
+
+    from sincpro_framework.tracing.provider import setup_otlp_provider
+
+    logger = create_logger("no-endpoint-test")
+    assert logger._getter_context is None  # no getter before
+
+    setup_otlp_provider("no-endpoint-test", logger)  # no endpoint in env
+
+    assert logger._getter_context is None  # getter must NOT be registered


### PR DESCRIPTION
# Pull Request Checklist

## Description Dev notes

This pull request enhances the integration between OpenTelemetry (OTel) tracing and the logging system, ensuring that trace context (trace_id and span_id) is automatically included in log outputs when OTel is active. It also introduces new tests to verify this behavior and updates dependencies for improved compatibility.

**OTel Tracing and Logging Integration:**

* The `setup_otlp_provider` function now accepts an optional `logger` argument and, when provided, wires the current OTel span context into the logger. This ensures that every `framework.logger.info(...)` call automatically includes `trace_id` and `span_id` from the active OTel span. [[1]](diffhunk://#diff-8dcdff2a4cb91d392ef0be16ae0674bdea64065cc7512fc285f641525ea1cd24L13-R31) [[2]](diffhunk://#diff-8dcdff2a4cb91d392ef0be16ae0674bdea64065cc7512fc285f641525ea1cd24R91-R95) [[3]](diffhunk://#diff-4d329c7e5decccf3335e8a9dbc793ba6076dd7a50b37d1209e0bed63f68782cdL133-R135)
* A new internal function `_get_current_otel_context` is introduced to extract the current span context from OTel and provide it to the logger.
* The logger property docstring in the framework is clarified.

**Testing Enhancements:**

* Several new tests are added to verify that the logger correctly includes or omits trace context depending on OTel span activity and configuration, and to ensure backward compatibility when OTel is not configured.

**Dependency and Configuration Updates:**

* The `sincpro-log` dependency is updated from `^1.0.1` to `^1.1.1` in `pyproject.toml` to support the new logging features.
* Poetry configuration is updated to specify the virtual environment path and name for `pyright` type checking.

## Checklist

- [ ] Did you test manually the changes
